### PR TITLE
Fixed #2: show protocol url directly.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -11,16 +11,12 @@ Mac OS X 平台都可以访问。甚至你可以用 `svn` 和 `hg`
 
 支持三种访问协议： 
 
-* [HTTP协议](https://github.com/gotgithub/helloworld.git)。
-* [Git协议](git://github.com/gotgithub/helloworld.git)。
-* [SSH协议][link3]。
+* HTTP协议： https://github.com/gotgithub/helloworld.git
+* Git协议： git://github.com/gotgithub/helloworld.git
+* SSH协议： ssh://git@github.com/gotgithub/helloworld
 
 ## 克隆版本库 ##
 
 操作示例：
 
     $ git clone git://github.com/gotgithub/helloworld.git
-
-----
-
-   [link3]: ssh://git@github.com/gotgithub/helloworld.git


### PR DESCRIPTION
GitHub favorate markdown does not support protocol other than http.
